### PR TITLE
 [chore] 강의 목록 페이지 데이터 패칭 변경(ISR + 클라이언트 캐싱)

### DIFF
--- a/api/lecture/getLectureListStatic.ts
+++ b/api/lecture/getLectureListStatic.ts
@@ -1,0 +1,59 @@
+import { HTTP_STATUS, ERROR_MESSAGES } from '@/constants';
+import type { LectureResponse, StaticLectureData } from '@/domains/lecture';
+
+export interface StaticLectureResult {
+  success: boolean;
+  lectures?: StaticLectureData[];
+  message?: string;
+}
+
+export async function getLectureListStatic(universityName: string): Promise<StaticLectureResult> {
+  try {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/class?university=${universityName}`,
+      {
+        cache: 'force-cache',
+        next: {
+          tags: [`lectures-${universityName}`],
+        },
+      }
+    );
+
+    const data: LectureResponse = await response.json();
+
+    if (data.status === HTTP_STATUS.OK && Array.isArray(data.data)) {
+      const staticLectures: StaticLectureData[] = data.data.map((lecture) => ({
+        lectureId: lecture.lectureId,
+        lectureName: lecture.lectureName,
+        department: lecture.department,
+        university: lecture.university,
+        lectureType: lecture.lectureType,
+        professor: lecture.professor,
+        opened: lecture.opened,
+        icon: lecture.icon,
+      }));
+
+      return {
+        success: true,
+        lectures: staticLectures,
+      };
+    }
+
+    if (data.status === HTTP_STATUS.UNAUTHORIZED) {
+      return {
+        success: false,
+        message: data.message || '해당 학교의 강의가 존재하지 않습니다.',
+      };
+    }
+
+    return {
+      success: false,
+      message: ERROR_MESSAGES.LECTURE_FETCH_FAILED,
+    };
+  } catch {
+    return {
+      success: false,
+      message: ERROR_MESSAGES.LECUTRE_FETCH_UNKNOWN_ERROR,
+    };
+  }
+}

--- a/api/lecture/getLectureRating.ts
+++ b/api/lecture/getLectureRating.ts
@@ -1,0 +1,41 @@
+import { HTTP_STATUS } from '@/constants';
+import type { DynamicLectureData } from '@/domains/lecture';
+
+export interface RatingResult {
+  success: boolean;
+  rating?: number;
+  message?: string;
+}
+
+export async function getLectureRating(
+  lectureId: number,
+  universityName: string
+): Promise<RatingResult> {
+  try {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/class?university=${universityName}&lectureId=${lectureId}`,
+      {
+        cache: 'no-store',
+      }
+    );
+
+    const data = await response.json();
+
+    if (data.status === HTTP_STATUS.OK && data.data?.averageStarLating !== undefined) {
+      return {
+        success: true,
+        rating: data.data.averageStarLating,
+      };
+    }
+
+    return {
+      success: false,
+      message: '평점 데이터를 불러올 수 없습니다.',
+    };
+  } catch {
+    return {
+      success: false,
+      message: '평점 조회 중 오류가 발생했습니다.',
+    };
+  }
+}

--- a/app/[universityName]/page.tsx
+++ b/app/[universityName]/page.tsx
@@ -1,16 +1,12 @@
 import { universityNames } from '@/constants';
-import { Suspense } from 'react';
-import { LectureList, LectureSelector, CardListSkeleton } from '@/domains/lecture';
-import { getLectureList } from '@/api/lecture';
+import { LectureListHybrid, LectureSelector } from '@/domains/lecture';
+import { getLectureListStatic } from '@/api/lecture';
 import styles from '@/styles/global.module.css';
 
-export async function generateStaticParams() {
-  return universityNames.map((name) => ({ universityName: name }));
-}
+export const revalidate = false;
 
-async function LectureListWrapper({ universityName }: { universityName: string }) {
-  const lectures = await getLectureList(universityName);
-  return <LectureList universityName={universityName} lectures={lectures} />;
+export async function generateStaticParams() {
+  return universityNames.map((name) => ({ universityName: encodeURIComponent(name) }));
 }
 
 export default async function UniversityPage({
@@ -21,12 +17,12 @@ export default async function UniversityPage({
   const { universityName } = await params;
   const decoded = decodeURIComponent(universityName);
 
+  const staticLectures = await getLectureListStatic(decoded);
+
   return (
     <main className={styles.paddingContainer}>
       <LectureSelector universityName={decoded} />
-      <Suspense fallback={<CardListSkeleton count={12} />}>
-        <LectureListWrapper universityName={decoded} />
-      </Suspense>
+      <LectureListHybrid universityName={decoded} lectures={staticLectures} />
     </main>
   );
 }

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,0 +1,75 @@
+// import { revalidateTag } from 'next/cache';
+// import { NextRequest, NextResponse } from 'next/server';
+
+// export async function POST(request: NextRequest) {
+//   try {
+//     const { universityName, action, secret } = await request.json();
+
+//     // 보안을 위한 secret 키 검증
+//     if (secret !== process.env.REVALIDATION_SECRET) {
+//       return NextResponse.json({ message: 'Invalid secret' }, { status: 401 });
+//     }
+
+//     if (!universityName) {
+//       return NextResponse.json({ message: 'University name is required' }, { status: 400 });
+//     }
+
+//     // 액션에 따른 재생성 로직
+//     switch (action) {
+//       case 'lecture_added':
+//       case 'lecture_removed':
+//       case 'lecture_modified':
+//         // 특정 대학교의 강의 목록 페이지 재생성
+//         await revalidateTag(`lectures-${universityName}`);
+//         console.log(`Revalidated lectures for ${universityName} - Action: ${action}`);
+//         break;
+
+//       case 'university_added':
+//         // 전체 대학교 목록 재생성 (필요한 경우)
+//         await revalidateTag('universities');
+//         console.log('Revalidated all universities');
+//         break;
+
+//       default:
+//         return NextResponse.json({ message: 'Invalid action' }, { status: 400 });
+//     }
+
+//     return NextResponse.json({
+//       revalidated: true,
+//       timestamp: new Date().toISOString(),
+//       action,
+//       universityName,
+//     });
+//   } catch (error) {
+//     console.error('Revalidation error:', error);
+//     return NextResponse.json({ message: 'Internal server error' }, { status: 500 });
+//   }
+// }
+
+// // GET 요청으로도 간단한 재생성 지원
+// export async function GET(request: NextRequest) {
+//   const searchParams = request.nextUrl.searchParams;
+//   const universityName = searchParams.get('university');
+//   const secret = searchParams.get('secret');
+
+//   if (secret !== process.env.REVALIDATION_SECRET) {
+//     return NextResponse.json({ message: 'Invalid secret' }, { status: 401 });
+//   }
+
+//   if (!universityName) {
+//     return NextResponse.json({ message: 'University name is required' }, { status: 400 });
+//   }
+
+//   try {
+//     await revalidateTag(`lectures-${universityName}`);
+
+//     return NextResponse.json({
+//       revalidated: true,
+//       universityName,
+//       timestamp: new Date().toISOString(),
+//     });
+//   } catch (error) {
+//     console.error('Revalidation error:', error);
+//     return NextResponse.json({ message: 'Internal server error' }, { status: 500 });
+//   }
+// }

--- a/domains/lecture/client/components/DynamicRating.tsx
+++ b/domains/lecture/client/components/DynamicRating.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { StarRating } from '@/components/common';
+import { useLectureRating } from '../hooks';
+
+interface DynamicRatingProps {
+  lectureId: number;
+  universityName: string;
+  size?: 'small' | 'medium' | 'large' | 'veryLarge';
+}
+
+export default function DynamicRating({
+  lectureId,
+  universityName,
+  size = 'large',
+}: DynamicRatingProps) {
+  const { data, isLoading, error } = useLectureRating({
+    lectureId,
+    universityName,
+  });
+
+  if (isLoading) {
+    return (
+      <div
+        style={{
+          width: '80px',
+          height: '24px',
+          backgroundColor: '#f0f0f0',
+          borderRadius: '4px',
+          animation: 'pulse 1.5s ease-in-out infinite',
+        }}
+      />
+    );
+  }
+
+  if (error || !data?.success) {
+    return <StarRating rating={0} size={size} />;
+  }
+
+  return <StarRating rating={data.rating || 0} size={size} />;
+}

--- a/domains/lecture/client/hooks/useLectureRating.ts
+++ b/domains/lecture/client/hooks/useLectureRating.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import { getLectureRating } from '@/api/lecture';
+
+interface UseLectureRatingParams {
+  lectureId: number;
+  universityName: string;
+}
+
+export function useLectureRating({ lectureId, universityName }: UseLectureRatingParams) {
+  return useQuery({
+    queryKey: ['lecture-rating', lectureId, universityName],
+    queryFn: () => getLectureRating(lectureId, universityName),
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 30,
+    refetchOnWindowFocus: false,
+    retry: 2,
+  });
+}

--- a/domains/lecture/index.ts
+++ b/domains/lecture/index.ts
@@ -3,6 +3,28 @@ export { default as LectureList } from './server/components/LectureList';
 export { default as LectureInfo } from './server/components/LectureInfo';
 export { default as LectureSelector } from './server/components/LectureSelector';
 
+export { default as LectureCardHybrid } from './server/components/LectureCardHybrid';
+export { default as LectureListHybrid } from './server/components/LectureListHybrid';
+
+export { default as DynamicRating } from './client/components/DynamicRating';
+
+export { useLectureRating } from './client/hooks';
+
 export { default as CardSkeleton } from './server/components/CardSkeleton';
 export { default as CardListSkeleton } from './server/components/CardListSkeleton';
 export { default as LectureInfoSkeleton } from './server/components/LectureInfoSkeleton';
+
+export type {
+  Lecture,
+  StaticLectureData,
+  DynamicLectureData,
+  LectureList,
+  LectureResponse,
+  LectureResult,
+} from './shared/types';
+export type {
+  LectureInfo,
+  LectureInfoList,
+  LectureInfoResponse,
+  LectureInfoResult,
+} from './shared/types/lectureInfo';

--- a/domains/lecture/server/components/LectureCardHybrid.tsx
+++ b/domains/lecture/server/components/LectureCardHybrid.tsx
@@ -1,0 +1,63 @@
+import { StaticLectureData } from '../../shared/types';
+import { BookOpen, Tag, Star } from 'lucide-react';
+import { DynamicRating } from '@/domains/lecture';
+import styles from '../../styles/LectureCard.module.css';
+
+interface LectureCardHybridProps {
+  staticData: StaticLectureData;
+  universityName: string;
+}
+
+export default function LectureCardHybrid({ staticData, universityName }: LectureCardHybridProps) {
+  return (
+    <div className={styles.cardContainer}>
+      <div className={styles.colorBar} />
+
+      <div className={styles.cardHeader}>
+        <div className={styles.cardInfo}>
+          <h3 className={styles.lectureName}>{staticData.lectureName}</h3>
+          <p className={styles.professor}>{staticData.professor}</p>
+        </div>
+        <div className={styles.cardStatus}>
+          <span
+            className={`${styles.statusBadge} ${staticData.opened ? styles.opened : styles.closed}`}
+          >
+            {staticData.opened ? '개설' : '폐강'}
+          </span>
+        </div>
+      </div>
+
+      <div className={styles.cardBody}>
+        <div className={styles.cardDetail}>
+          <span className={styles.label}>
+            <BookOpen size={14} className={styles.icon} />
+            학과
+          </span>
+          <span className={styles.value}>{staticData.department}</span>
+        </div>
+        <div className={styles.cardDetail}>
+          <span className={styles.label}>
+            <Tag size={14} className={styles.icon} />
+            구분
+          </span>
+          <span className={styles.value}>
+            <span className={styles.lectureTypeBadge}>{staticData.lectureType}</span>
+          </span>
+        </div>
+        <div className={styles.cardDetail}>
+          <span className={styles.label}>
+            <Star size={14} className={styles.icon} />
+            평점
+          </span>
+          <div className={styles.ratingContainer}>
+            <DynamicRating
+              lectureId={staticData.lectureId}
+              universityName={universityName}
+              size="large"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/domains/lecture/server/components/LectureListHybrid.tsx
+++ b/domains/lecture/server/components/LectureListHybrid.tsx
@@ -1,0 +1,48 @@
+import { StaticLectureResult } from '@/api/lecture/getLectureListStatic';
+import { StaticLectureData } from '../../shared/types';
+import LectureCardHybrid from './LectureCardHybrid';
+import Link from 'next/link';
+import styles from '../../styles/LectureList.module.css';
+
+interface LectureListHybridProps {
+  universityName: string;
+  lectures: StaticLectureResult;
+}
+
+export default function LectureListHybrid({ universityName, lectures }: LectureListHybridProps) {
+  if (!lectures.success || !lectures.lectures) {
+    return (
+      <main className={styles.noLectureContainer}>
+        <div>{lectures.message || '강의를 불러오는데 실패했습니다.'}</div>
+      </main>
+    );
+  }
+
+  const lectureList = lectures.lectures.map((lecture: StaticLectureData) => ({
+    lectureId: lecture.lectureId,
+    lectureName: lecture.lectureName,
+    department: lecture.department,
+    university: lecture.university,
+    lectureType: lecture.lectureType,
+    professor: lecture.professor,
+    opened: lecture.opened,
+    icon: lecture.icon,
+  }));
+
+  return (
+    <main className={styles.lectureListContainer}>
+      {lectureList.map((lecture: StaticLectureData) => {
+        const encodedOpened = encodeURIComponent(String(lecture.opened));
+
+        return (
+          <Link
+            href={`/${universityName}/${lecture.lectureId}?opened=${encodedOpened}`}
+            key={lecture.lectureId}
+          >
+            <LectureCardHybrid staticData={lecture} universityName={universityName} />
+          </Link>
+        );
+      })}
+    </main>
+  );
+}

--- a/domains/lecture/shared/types/index.ts
+++ b/domains/lecture/shared/types/index.ts
@@ -1,0 +1,41 @@
+export interface Lecture {
+  lectureId: number;
+  lectureName: string;
+  department: string;
+  university: string;
+  lectureType: string;
+  averageStarLating: number;
+  professor: string;
+  opened: boolean;
+  icon: string;
+}
+
+export interface StaticLectureData {
+  lectureId: number;
+  lectureName: string;
+  department: string;
+  university: string;
+  lectureType: string;
+  professor: string;
+  opened: boolean;
+  icon: string;
+}
+
+export interface DynamicLectureData {
+  lectureId: number;
+  averageStarLating: number;
+}
+
+export type LectureList = Lecture[];
+
+export interface LectureResponse {
+  status: number;
+  message: string;
+  data: LectureList | null;
+}
+
+export interface LectureResult {
+  success: boolean;
+  lectures?: LectureList;
+  message?: string;
+}


### PR DESCRIPTION
### 주요 변경 사항
- 강의 목록 페이지에 on-demand ISR + 클라이언트 캐싱 추가
- API 수정 불가 새로운 데이터 패칭 플로우 적용
  - 정적 데이터(강의 정보)는 ISR로 사전덴더링 이후 변경 감지후 API 호출을 통한 revalidation, 동적정보(평점)는 강의정보에서 따로 추출하여 React Query로 클라이언트 캐싱으로 관리 및 재검증
- 사용하지 않는 구 컴포넌트 및 API 함수 정리

### 작업 내용
  - 데이터 처리 전략 변경
    - 기존: 강의 목록의 모든 데이터(강의정보 + 평점)를 force-cache로 일괄 처리
    - 변경: 평점 데이터를 분리하여 클라이언트 캐싱으로 동적 갱신 가능하도록 개선, 나머지 준정적 데이터(기타 강의 데이터)는 ISR로 처리
  - 새로운 데이터 플로우
    a. 정적 데이터 처리: 새로 만든 revalidation API 라우트를 호출해야만 데이터 업데이트 발생
    b. 평점 데이터 처리: React Query를 이용하여 CSR로 처리
      - 평점 데이터가 변경되지 않으면 기존 캐시 데이터 유지
      - 평점 데이터가 변경되면 새로운 데이터로 자동 교체
      - 일정 시간(5분) 동안 변경이 없으면 자동으로 리프레시하여 최신 상태 보장

  - 컴포넌트 구조 개선
    - LectureListHybrid, LectureCardHybrid - 정적/동적 데이터 분리 렌더링
    - DynamicRating - 클라이언트 사이드 평점 전용 컴포넌트
    - useLectureRating - 평점 데이터 캐싱 전용 훅
  - API 분리
    - getLectureListStatic - ISR용 정적 강의 데이터
    - getLectureRating - 동적 평점 데이터 전용
    - revalidate 엔드포인트 - 온디맨드 캐시 무효화
   

자세한 내용은 블로그에 정리하였음:  
👉 https://solplog.vercel.app/articles/post-8