### PR TITLE
[feat] SSR Hydration으로 평점 로딩 플래시 제거

### DIFF
--- a/app/[universityName]/page.tsx
+++ b/app/[universityName]/page.tsx
@@ -3,6 +3,8 @@ import { LectureListHybrid } from '@/domains/lecture';
 import LectureSelector from './components/LectureSelector';
 import { getLectureListStatic } from '@/api/lecture';
 import styles from '@/styles/global.module.css';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import { createQueryClient, prefetchMultipleLectureRatings } from '@/utils';
 
 export const revalidate = false;
 
@@ -20,10 +22,18 @@ export default async function UniversityPage({
 
   const staticLectures = await getLectureListStatic(decoded);
 
+  const queryClient = createQueryClient();
+
+  if (staticLectures.success && staticLectures.lectures) {
+    await prefetchMultipleLectureRatings(queryClient, staticLectures.lectures, decoded);
+  }
+
   return (
-    <main className={styles.paddingContainer}>
-      <LectureSelector universityName={decoded} />
-      <LectureListHybrid universityName={decoded} lectures={staticLectures} />
-    </main>
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <main className={styles.paddingContainer}>
+        <LectureSelector universityName={decoded} />
+        <LectureListHybrid universityName={decoded} lectures={staticLectures} />
+      </main>
+    </HydrationBoundary>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
-import { ReactQueryProvider } from './providers';
+import { AppProviders } from './providers';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -26,9 +26,9 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
-        <ReactQueryProvider>
+        <AppProviders>
           <div>{children}</div>
-        </ReactQueryProvider>
+        </AppProviders>
       </body>
     </html>
   );

--- a/app/providers/AppProviders.tsx
+++ b/app/providers/AppProviders.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+import { ReactNode } from 'react';
+import ReactQueryProvider from './ReactQueryProvider';
+
+interface AppProvidersProps {
+  children: ReactNode;
+}
+
+export default function AppProviders({ children }: AppProvidersProps) {
+  return <ReactQueryProvider>{children}</ReactQueryProvider>;
+}

--- a/app/providers/ReactQueryProvider.tsx
+++ b/app/providers/ReactQueryProvider.tsx
@@ -1,9 +1,21 @@
 'use client';
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { ReactNode, useState } from 'react';
+import { createQueryClient } from '@/utils';
 
-export default function ReactQueryProvider({ children }: { children: ReactNode }) {
-  const [queryClient] = useState(() => new QueryClient());
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+interface ReactQueryProviderProps {
+  children: ReactNode;
+}
+
+export default function ReactQueryProvider({ children }: ReactQueryProviderProps) {
+  const [queryClient] = useState(() => createQueryClient());
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      {process.env.NODE_ENV === 'development' && <ReactQueryDevtools initialIsOpen={false} />}
+    </QueryClientProvider>
+  );
 }

--- a/app/providers/index.ts
+++ b/app/providers/index.ts
@@ -1,1 +1,2 @@
 export { default as ReactQueryProvider } from './ReactQueryProvider';
+export { default as AppProviders } from './AppProviders';

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@eslint/js": "^9.30.1",
+    "@tanstack/react-query-devtools": "^5.83.0",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/utils/Index.ts
+++ b/utils/Index.ts
@@ -1,2 +1,4 @@
 export * from './delay';
 export * from './universityUtils';
+export * from './queryClient';
+export * from './queryPrefetch';

--- a/utils/queryClient.ts
+++ b/utils/queryClient.ts
@@ -1,0 +1,14 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 1000 * 60 * 5,
+        gcTime: 1000 * 60 * 30,
+        refetchOnWindowFocus: false,
+        retry: 2,
+      },
+    },
+  });
+}

--- a/utils/queryPrefetch.ts
+++ b/utils/queryPrefetch.ts
@@ -1,0 +1,25 @@
+import { QueryClient } from '@tanstack/react-query';
+import { getLectureRating } from '@/api/lecture';
+import type { StaticLectureData } from '@/domains/lecture';
+
+export async function prefetchLectureRating(
+  queryClient: QueryClient,
+  lectureId: number,
+  universityName: string
+): Promise<void> {
+  await queryClient.prefetchQuery({
+    queryKey: ['lecture-rating', lectureId, universityName],
+    queryFn: () => getLectureRating(lectureId, universityName),
+    staleTime: 1000 * 60 * 5,
+  });
+}
+
+export async function prefetchMultipleLectureRatings(
+  queryClient: QueryClient,
+  lectures: StaticLectureData[],
+  universityName: string
+): Promise<void> {
+  await Promise.allSettled(
+    lectures.map((lecture) => prefetchLectureRating(queryClient, lecture.lectureId, universityName))
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -406,6 +406,18 @@
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.83.0.tgz#ac3bf337007bb7ea97b1fd2e7c3ceb4240f36dbc"
   integrity sha512-0M8dA+amXUkyz5cVUm/B+zSk3xkQAcuXuz5/Q/LveT4ots2rBpPTZOzd7yJa2Utsf8D2Upl5KyjhHRY+9lB/XA==
 
+"@tanstack/query-devtools@5.81.2":
+  version "5.81.2"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-devtools/-/query-devtools-5.81.2.tgz#9ac478de2f441881e299d3280063d34c53828234"
+  integrity sha512-jCeJcDCwKfoyyBXjXe9+Lo8aTkavygHHsUHAlxQKKaDeyT0qyQNLKl7+UyqYH2dDF6UN/14873IPBHchcsU+Zg==
+
+"@tanstack/react-query-devtools@^5.83.0":
+  version "5.83.0"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query-devtools/-/react-query-devtools-5.83.0.tgz#551c5e557b93122b54986f6aacebe5edbba95ed0"
+  integrity sha512-yfp8Uqd3I1jgx8gl0lxbSSESu5y4MO2ThOPBnGNTYs0P+ZFu+E9g5IdOngyUGuo6Uz6Qa7p9TLdZEX3ntik2fQ==
+  dependencies:
+    "@tanstack/query-devtools" "5.81.2"
+
 "@tanstack/react-query@^5.83.0":
   version "5.83.0"
   resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.83.0.tgz#e72cacdb03d2e6a7e4f82f5b2fc228118941d499"


### PR DESCRIPTION
## 주요 변경사항
  - React Query SSR Hydration 구현으로 새로고침 시 평점 즉시 표시
  - 서버사이드 prefetching을 통한 초기 캐시 데이터 제공
  - 코드 구조 모듈화 및 deprecated API 제거

  ### SSR Hydration 구현
  - 서버에서 평점 데이터를 미리 prefetch하여 클라이언트로 전달
  - HydrationBoundary를 통한 서버-클라이언트 캐시 동기화
  - 새로고침해도 평점이 로딩 없이 즉시 표시

  ### 코드 구조 개선
  - utils/queryClient.ts: QueryClient 생성 로직 중앙화
  - utils/queryPrefetch.ts: prefetch 로직 모듈화 및 재사용성 확보
  - AppProviders.tsx: 통합 프로바이더 구조로 확장성 개선